### PR TITLE
Activate UnityExplorer only after a keybind is hit

### DIFF
--- a/KeyboardMono.cs
+++ b/KeyboardMono.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Modding;
+using UnityEngine;
+
+namespace UExplorer
+{
+    public class KeyboardMono: MonoBehaviour{
+        public void Update(){
+            if(Input.GetKeyDown(KeyCode.F7)){
+                UExplorer.Instance.InitExplorer();
+            }
+        }
+    }
+}

--- a/KeyboardMono.cs
+++ b/KeyboardMono.cs
@@ -1,14 +1,13 @@
-using System;
-using System.Linq;
-using System.Reflection;
-using Modding;
 using UnityEngine;
 
 namespace UExplorer
 {
-    public class KeyboardMono: MonoBehaviour{
-        public void Update(){
-            if(Input.GetKeyDown(KeyCode.F7)){
+    public class KeyboardMono : MonoBehaviour
+    {
+        public void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.F7))
+            {
                 UExplorer.Instance.InitExplorer();
             }
         }

--- a/UExplorer.cs
+++ b/UExplorer.cs
@@ -1,10 +1,10 @@
-﻿using System;
+﻿using Modding;
+using MonoMod.RuntimeDetour.HookGen;
+using System;
 using System.Linq;
 using System.Reflection;
-using Modding;
 using UnityEngine;
 using UnityExplorer;
-using MonoMod.RuntimeDetour.HookGen;
 using UnityExplorer.Inspectors;
 using UnityExplorer.Inspectors.MouseInspectors;
 
@@ -23,15 +23,18 @@ namespace UExplorer
         public override void Initialize()
         {
             Instance = this;
-            if(UEobject == null){
+            if (UEobject == null)
+            {
                 UEobject = new GameObject("Unity Explorer Silent Object");
                 GameObject.DontDestroyOnLoad(UEobject);
                 UEobject.AddComponent<KeyboardMono>();
             }
         }
 
-        internal void InitExplorer(){
-            if(!isInitialized){
+        internal void InitExplorer()
+        {
+            if (!isInitialized)
+            {
                 isInitialized = true;
                 ExplorerStandalone.CreateInstance();
                 ExplorerStandalone.OnLog += OnLog;
@@ -69,7 +72,7 @@ namespace UExplorer
             var hits = Physics2D.OverlapPointAll(worldPos, Physics2D.AllLayers);
             var hit = hits.FirstOrDefault(x => x.transform.position.z > 0)
                  ?? hits.LastOrDefault();
-            
+
             if (hit == null)
             {
                 //if (ReflectionHelper.GetField<WorldInspector, GameObject>(self, "lastHitObject") != null)

--- a/UExplorer.cs
+++ b/UExplorer.cs
@@ -16,12 +16,27 @@ namespace UExplorer
 
         public UExplorer() : base("Unity Explorer") { }
 
+        private GameObject UEobject;
+        internal static UExplorer Instance;
+        private bool isInitialized = false;
+
         public override void Initialize()
         {
-            ExplorerStandalone.CreateInstance();
-            ExplorerStandalone.OnLog += OnLog;
+            Instance = this;
+            if(UEobject == null){
+                UEobject = new GameObject("Unity Explorer Silent Object");
+                GameObject.DontDestroyOnLoad(UEobject);
+                UEobject.AddComponent<KeyboardMono>();
+            }
+        }
 
-            PatchWorldInspector();
+        internal void InitExplorer(){
+            if(!isInitialized){
+                isInitialized = true;
+                ExplorerStandalone.CreateInstance();
+                ExplorerStandalone.OnLog += OnLog;
+                PatchWorldInspector();
+            }
         }
 
         //private static IDetour detour_UpdateMouseInspect;


### PR DESCRIPTION
Makes it so one can have the mod always loaded without worry of it messing up with anything else.